### PR TITLE
[do-not-merge] chore: Update for v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
   },
   "dependencies": {
     "@mdx-js/react": "^2.1.2",
-    "gatsby": "^4.21.0",
-    "gatsby-plugin-image": "^2.20.0",
-    "gatsby-plugin-mdx": "^4.0.0",
-    "gatsby-plugin-sharp": "^4.20.0",
-    "gatsby-source-filesystem": "^4.20.0",
-    "gatsby-transformer-sharp": "^4.20.0",
+    "gatsby": "^5.0.0",
+    "gatsby-plugin-image": "^3.0.0",
+    "gatsby-plugin-mdx": "^5.0.0",
+    "gatsby-plugin-sharp": "^5.0.0",
+    "gatsby-source-filesystem": "^5.0.0",
+    "gatsby-transformer-sharp": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/src/pages/blog/index.js
+++ b/src/pages/blog/index.js
@@ -25,7 +25,7 @@ const BlogPage = ({ data }) => {
 
 export const query = graphql`
   query {
-    allMdx(sort: {fields: frontmatter___date, order: DESC}) {
+    allMdx(sort: { frontmatter: { date: DESC }}) {
       nodes {
         frontmatter {
           date(formatString: "MMMM D, YYYY")


### PR DESCRIPTION
Should not be merged until https://github.com/gatsbyjs/gatsby/pull/36763 is.

Since deps should reflect most closely what `gatsby new` creates (rather than the `next` dist tag) we should double check these changes work as expected after `5.0.0` is released.

[sc-57105]